### PR TITLE
Add --scope flag to override commit scope

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ program
   .option('-s, --style <type>', 'Commit style: conventional or simple', 'conventional')
   .option('-l, --language <lang>', 'Message language (en, tr, etc.)', 'en')
   .option('-e, --emoji', 'Include emoji in commit message')
+  .option('--scope <name>', 'Override commit scope (e.g., auth, api, ui)')
   .option('-y, --yes', 'Auto-commit without confirmation')
   .option('-n, --dry-run', 'Generate message but don\'t commit')
   .option('-r, --regenerate', 'Keep regenerating until satisfied')
@@ -40,6 +41,7 @@ program
       style: options.style || config.style || 'conventional',
       language: options.language || config.language || 'en',
       emoji: options.emoji || config.emoji || false,
+      scope: options.scope,
     };
 
     console.log('');

--- a/src/core/generate.ts
+++ b/src/core/generate.ts
@@ -9,6 +9,7 @@ export interface GenerateOptions {
   style?: 'conventional' | 'simple';
   language?: string;
   emoji?: boolean;
+  scope?: string;
 }
 
 export function getProvider(name?: ProviderName): AIProvider {

--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -1,11 +1,16 @@
 import type { DiffAnalysis } from './diff.js';
 import { getRecentCommits } from '../lib/git.js';
 
-export function buildPrompt(analysis: DiffAnalysis, options?: { style?: string; language?: string; emoji?: boolean }): string {
+export function buildPrompt(analysis: DiffAnalysis, options?: { style?: string; language?: string; emoji?: boolean; scope?: string }): string {
   const recentCommits = getRecentCommits(5);
   const style = options?.style || 'conventional';
   const language = options?.language || 'en';
   const emoji = options?.emoji ?? false;
+  const scope = options?.scope;
+
+  const scopeInstruction = scope 
+    ? `- Scope: use "${scope}" (manually specified)`
+    : '- Scope: infer from file paths (e.g., auth, api, ui, config)';
 
   return `You are a git commit message generator. Analyze the diff and generate a professional commit message.
 
@@ -16,7 +21,7 @@ RULES:
 - ${emoji ? 'Include a relevant emoji at the start of the description' : 'No emojis'}
 - If multiple changes, add bullet points in the body
 - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
-- Scope: infer from file paths (e.g., auth, api, ui, config)
+${scopeInstruction}
 - Do NOT include the diff in the message
 - Do NOT explain what a commit message is
 - Output ONLY the commit message, nothing else


### PR DESCRIPTION
## Description
Implements manual scope override as requested in #2, allowing users to specify commit scope instead of relying on auto-detection.

## Changes
- Added `--scope` option to CLI
- Updated `GenerateOptions` interface to include scope parameter
- Modified `buildPrompt()` to use manual scope when provided
- Falls back to auto-detection when scope not specified
- Works seamlessly with conventional commit style

## Usage

### Manual Scope
```bash
# Specify scope manually
aic --scope auth
aic --scope api
aic --scope ui
aic --scope config

# Combine with other options
aic --scope auth --emoji
aic --scope api --style conventional --language en
```

### Auto-Detection (Default)
```bash
# Without --scope, auto-detects from file paths
aic
```

## Example Output

### With Manual Scope
```
aic --scope auth
→ feat(auth): add JWT token validation
→ fix(auth): handle expired tokens gracefully
```

### Auto-Detection
```
aic
→ feat(api): add user endpoint
→ fix(ui): correct button alignment
```

## Implementation Details

### Prompt Modification
When `--scope` is provided:
```
- Scope: use auth (manually specified)
```

When not provided:
```
- Scope: infer from file paths (e.g., auth, api, ui, config)
```

### Type Safety
```typescript
export interface GenerateOptions {
  provider?: ProviderName;
  style?: 'conventional' | 'simple';
  language?: string;
  emoji?: boolean;
  scope?: string;  // New optional parameter
}
```

## Use Cases
1. **Monorepo projects** - Specify module/package scope explicitly
2. **Cross-cutting changes** - Override when files span multiple scopes
3. **Consistency** - Enforce specific scope naming conventions
4. **Clarity** - Make scope explicit when auto-detection might be ambiguous

## Benefits
- Full control over commit scope
- No breaking changes (scope is optional)
- Works with existing auto-detection
- Compatible with all commit styles
- Follows Conventional Commits specification

## Testing
- Verified manual scope appears in generated message
- Tested with conventional commit style
- Confirmed auto-detection still works when flag omitted
- Validated with various scope names

Fixes #2